### PR TITLE
fix: Token header incorrect format

### DIFF
--- a/octopin/github.py
+++ b/octopin/github.py
@@ -66,7 +66,7 @@ class GitHubAPI:
             return dict(headers)
         else:
             new_headers = dict(headers)
-            new_headers.update({"Authorization": f"Bearer: {self._token}"})
+            new_headers.update({"Authorization": f"Bearer {self._token}"})
             return new_headers
 
     async def get_default_branch(self, owner: str, repo: str) -> str:


### PR DESCRIPTION
The Token header has an extra colon in it that shouldn't be there. This removes the colon so that the GitHub Token is correctly passed into request header.

Changes `Bearer: TOKEN` to `Bearer TOKEN`.