### PR TITLE
feat: Read GITHUB_TOKEN if token is not passed

### DIFF
--- a/octopin/pin.py
+++ b/octopin/pin.py
@@ -94,13 +94,19 @@ def pin(
     ] = False,
     token: Annotated[
         str | None,
-        typer.Option(help="GitHub token to use."),
+        typer.Option(
+            help="GitHub token to use. Reads GITHUB_TOKEN from the environment if not provided.",
+            envvar=["GITHUB_TOKEN", "GH_TOKEN"],
+        ),
     ] = None,
     verbose: bool = typer.Option(False, help="Enable verbose output"),
 ) -> int:
     """
     Pin actions used in multiple workflows by calling `pin` for each workflow.
     """
+    if not token:
+        print("[yellow]Warn: GitHub token not provided. Proceeding unauthenticated.")
+
     return_code = 0
 
     for workflow in workflows:


### PR DESCRIPTION
Reads environment variable GITHUB_TOKEN if the token is not passed via the `--token` parameter. If neither are passed will proceed unauthenticated.

Using the envvar GITHUB_TOKEN to match what is available when run from inside an action in GitHub. So that auth will automatically just work if this is run from a GitHub Workflow.

Closes issue #19.

Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication