### PR TITLE
fix: retain leading characters when replacing a workflow line

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
     rev: v1.13.0
     hooks:
       - id: mypy
+        exclude: ^(tests)/
         additional_dependencies: [types-PyYAML,typer]
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1

--- a/octopin/pin.py
+++ b/octopin/pin.py
@@ -150,7 +150,7 @@ async def _handle_async(workflow_ref: ActionRef, token: str | None) -> tuple[Wor
 
         pinned_lines = []
         for line in workflow_file.lines:
-            pinned_lines.append(re.sub(r"^[^#\n]*((uses:\s+)([^\s#]+)((\s+#)([^\n]+))?)(?=\n?)", pin, line))
+            pinned_lines.append(re.sub(r"^(([^#\n]*uses:\s+)([^\s#]+)((\s+#)([^\n]+))?)(?=\n?)", pin, line))
 
         return workflow_file, pinned_lines
 

--- a/octopin/pin.py
+++ b/octopin/pin.py
@@ -1,5 +1,5 @@
 #  *******************************************************************************
-#  Copyright (c) 2023-2024 Eclipse Foundation and others.
+#  Copyright (c) 2023-2025 Eclipse Foundation and others.
 #  This program and the accompanying materials are made available
 #  under the terms of the Eclipse Public License 2.0
 #  which is available at http://www.eclipse.org/legal/epl-v20.html
@@ -145,14 +145,18 @@ async def _handle_async(workflow_ref: ActionRef, token: str | None) -> tuple[Wor
             else:
                 pinned_actions[orig_action] = f"{pinned_action!r}"
 
-        def pin(m: re.Match[str]) -> str:
-            return str(m.group(2) + pinned_actions[m.group(3)])
-
         pinned_lines = []
         for line in workflow_file.lines:
-            pinned_lines.append(re.sub(r"^(([^#\n]*uses:\s+)([^\s#]+)((\s+#)([^\n]+))?)(?=\n?)", pin, line))
+            pinned_lines.append(pin_action_on_line_if_needed(line, pinned_actions))
 
         return workflow_file, pinned_lines
+
+
+def pin_action_on_line_if_needed(line: str, pinned_actions: dict[str, str]) -> str:
+    def _pin_action(m: re.Match[str]) -> str:
+        return str(m.group(2) + pinned_actions[m.group(3)])
+
+    return re.sub(r"^(([^#\n]*uses:\s+)([^\s#]+)((\s+#)([^\n]+))?)(?=\n?)", _pin_action, line)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ asyncio_default_fixture_loop_scope="function"
 [tool.mypy]
 python_version = "3.11"
 strict         = true
-exclude        = ["docs"]
+exclude        = ["docs", "tests"]
 
 [[tool.mypy.overrides]]
 module = [

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -1,0 +1,36 @@
+#  *******************************************************************************
+#  Copyright (c) 2025 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+import pytest
+
+from octopin.pin import pin_action_on_line_if_needed
+
+_pinned_actions: dict[str, str] = {
+    "actions/checkout@v4": "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2"
+}
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        (
+            "#        uses: actions/checkout@v4",
+            "#        uses: actions/checkout@v4",
+        ),
+        (
+            "        uses: actions/checkout@v4",
+            "        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2",
+        ),
+        (
+            "      - uses: actions/checkout@v4",
+            "      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2",
+        ),
+    ],
+)
+def test_pin_action_on_line_if_needed(line: str, expected: str) -> None:
+    assert pin_action_on_line_if_needed(line, _pinned_actions) == expected


### PR DESCRIPTION
Perhaps we should also explicitly only accept whitespace, instead of any prefix? I kept the diff as small as possible for now.

Sadly without a unit test, that would've needed a bigger refactor

fixes #41 