### PR TITLE
Support a comment to ignore actions from being pinned

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ instead of tag to improve security as Git tags are not immutable.
 Converts `uses: aws-actions/configure-aws-credentials@v1.7.0` to
 `uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0`
 
+## Skipping actions
+
+To skip a specific action from being pinned, you can add a comment `pinning: ignore`.
+
+Example using the generic SLSA generator action which *MUST* be [referenced](https://github.com/slsa-framework/slsa-github-generator?tab=readme-ov-file#referencing-slsa-builders-and-generators) by a tag rather than a commit hash:
+
+```yaml
+provenance:
+    needs: ['prepare', 'build-dist']
+    permissions:
+      actions: read
+      contents: write
+      id-token: write # Needed to access the workflow's OIDC identity.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 # pinning: ignore
+    with:
+      base64-subjects: "${{ needs.build-dist.outputs.hashes }}"
+      upload-assets: true
+```
 
 ## pre-commit hook
 

--- a/octopin/pin.py
+++ b/octopin/pin.py
@@ -154,7 +154,14 @@ async def _handle_async(workflow_ref: ActionRef, token: str | None) -> tuple[Wor
 
 def pin_action_on_line_if_needed(line: str, pinned_actions: dict[str, str]) -> str:
     def _pin_action(m: re.Match[str]) -> str:
-        return str(m.group(2) + pinned_actions[m.group(3)])
+        prefix = m.group(2)
+        unpinned_action = m.group(3)
+        comment = m.group(6)
+
+        if comment is not None and "pinning: ignore" in comment:
+            return m.group(0)
+
+        return str(prefix + pinned_actions[unpinned_action])
 
     return re.sub(r"^(([^#\n]*uses:\s+)([^\s#]+)((\s+#)([^\n]+))?)(?=\n?)", _pin_action, line)
 

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -34,6 +34,10 @@ _pinned_actions: dict[str, str] = {
             "      - uses: actions/checkout@v4 # v4",
             "      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2",
         ),
+        (
+            "      - uses: mysuperduperorg/mysuperduperaction@v4  # pinning: ignore",
+            "      - uses: mysuperduperorg/mysuperduperaction@v4  # pinning: ignore",
+        ),
     ],
 )
 def test_pin_action_on_line_if_needed(line: str, expected: str) -> None:

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -18,25 +18,35 @@ _pinned_actions: dict[str, str] = {
 @pytest.mark.parametrize(
     "line, expected",
     [
+        # commented out lines should not be pinned
         (
             "#        uses: actions/checkout@v4",
             "#        uses: actions/checkout@v4",
         ),
+        # nominal case, w/o leading '-'
         (
             "        uses: actions/checkout@v4",
             "        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2",
         ),
+        # nominal case, with leading '-'
         (
             "      - uses: actions/checkout@v4",
             "      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2",
         ),
+        # replace existing comment with actual version being pinned
         (
             "      - uses: actions/checkout@v4 # v4",
             "      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2",
         ),
+        # ignore action due to comment, does not exist in pinned actions
         (
             "      - uses: mysuperduperorg/mysuperduperaction@v4  # pinning: ignore",
             "      - uses: mysuperduperorg/mysuperduperaction@v4  # pinning: ignore",
+        ),
+        # ignore action due to comment, exists in pinned actions
+        (
+            "      - uses: actions/checkout@v4  # pinning: ignore",
+            "      - uses: actions/checkout@v4  # pinning: ignore",
         ),
     ],
 )


### PR DESCRIPTION
This adds support for ignoring certain actions from being pinned:


```
    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 # pinning: ignore
```

@raboof 